### PR TITLE
Bugfix/show password length

### DIFF
--- a/__tests__/__snapshots__/generator.spec.js.snap
+++ b/__tests__/__snapshots__/generator.spec.js.snap
@@ -50,7 +50,9 @@ exports[`generator initial render remains consistent 1`] = `
               type="range"
               value={20}
             />
-            <span />
+            <span>
+              20
+            </span>
           </styled.div>
           <styled.div>
             <input
@@ -192,7 +194,9 @@ exports[`generator initial render remains consistent 1`] = `
                       type="range"
                       value="20"
                     />
-                    <span />
+                    <span>
+                      20
+                    </span>
                   </div>
                   <div
                     class="sc-dnqmqq jPiRWc"
@@ -336,7 +340,9 @@ exports[`generator initial render remains consistent 1`] = `
                 type="range"
                 value={20}
               />
-              <span />
+              <span>
+                20
+              </span>
             </styled.div>
             <styled.div>
               <input
@@ -521,7 +527,9 @@ exports[`generator initial render remains consistent 1`] = `
                         type="range"
                         value={20}
                       />
-                      <span />
+                      <span>
+                        20
+                      </span>
                     </div>
                   </styled.div>
                   <styled.div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@buttercup/ui",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buttercup/ui",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Buttercup UI Components in React",
   "main": "dist/index.js",
   "repository": "git@github.com:buttercup/buttercup-ui.git",

--- a/src/components/generator.js
+++ b/src/components/generator.js
@@ -240,7 +240,7 @@ export class GeneratorUserInterface extends Component {
                 max="50"
                 onChange={e => this.changeLength(e)}
               />
-              <span>{this.state.length}</span>
+              <span>{this.state.config.randomCharacters.length}</span>
             </GeneratorRangeLabel>
             <GeneratorLabel>
               <input


### PR DESCRIPTION
The current generator shows an empty space where it should be showing the current password length

![image](https://user-images.githubusercontent.com/768052/38556838-b6f5bfc6-3cd3-11e8-9ccb-1c149620ea45.png)
